### PR TITLE
Improve term rendering and escaping

### DIFF
--- a/archive-songs.php
+++ b/archive-songs.php
@@ -33,26 +33,55 @@
 				<h4><a href="<?php the_permalink(); ?>"><strong><?php the_title(); ?></strong></a></h4>
 				</div>
 				<div class="song-card-middle">
+					<?php
+					$performer_id = get_the_ID();
+					$key_output   = '<strong>' . esc_html__( 'N/A', 'music-director' ) . '</strong>';
+					$tempo_output = esc_html__( 'N/A', 'music-director' );
+
+					$key_terms = get_the_terms( $performer_id, 'key' );
+					if ( ! empty( $key_terms ) && ! is_wp_error( $key_terms ) ) {
+						$key_names = wp_list_pluck( $key_terms, 'name', 'term_id' );
+						$key_links = array();
+
+						foreach ( $key_terms as $key_term ) {
+							$key_name = isset( $key_names[ $key_term->term_id ] ) ? $key_names[ $key_term->term_id ] : $key_term->name;
+							$key_link = get_term_link( $key_term, 'key' );
+
+							if ( ! is_wp_error( $key_link ) ) {
+								$key_links[] = '<a href="' . esc_url( $key_link ) . '"><strong>' . esc_html( $key_name ) . '</strong></a>';
+							} else {
+								$key_links[] = '<strong>' . esc_html( $key_name ) . '</strong>';
+							}
+						}
+
+						$key_output = implode( ', ', $key_links );
+					}
+
+					$tempo_terms = get_the_terms( $performer_id, 'tempo' );
+					if ( ! empty( $tempo_terms ) && ! is_wp_error( $tempo_terms ) ) {
+						$tempo_names = wp_list_pluck( $tempo_terms, 'name', 'term_id' );
+						$tempo_links = array();
+
+						foreach ( $tempo_terms as $tempo_term ) {
+							$tempo_name = isset( $tempo_names[ $tempo_term->term_id ] ) ? $tempo_names[ $tempo_term->term_id ] : $tempo_term->name;
+							$tempo_link = get_term_link( $tempo_term, 'tempo' );
+
+							if ( ! is_wp_error( $tempo_link ) ) {
+								$tempo_links[] = '<a href="' . esc_url( $tempo_link ) . '">' . esc_html( $tempo_name ) . '</a>';
+							} else {
+								$tempo_links[] = esc_html( $tempo_name );
+							}
+						}
+
+						$tempo_output = implode( ', ', $tempo_links );
+					}
+					?>
 					<div class="song-details">
 						<div class="move-left">
-							<small><strong>Key:</strong> <?php $terms = get_the_terms( $post->ID , 'key' ); 
-						    foreach ( $terms as $term ) {
-						        $term_link = get_term_link( $term, 'key' );
-						        if( is_wp_error( $term_link ) )
-						        continue;
-						    echo '<a href="' . $term_link . '">' . $term->name . '</a>' . ', ';
-						    } 
-						    $output = ob_get_clean(); echo rtrim($output, ', ');?></small> 
+							<small><strong>Key:</strong> <?php echo $key_output; ?></small> 
 						</div>
 						<div class="move-right">
-							<small><strong>Tempo:</strong> <?php $terms = get_the_terms( $post->ID , 'tempo' ); 
-						    foreach ( $terms as $term ) {
-						        $term_link = get_term_link( $term, 'tempo' );
-						        if( is_wp_error( $term_link ) )
-						        continue;
-						    echo '<a href="' . $term_link . '">' . $term->name . '</a>' . ', ';
-						    } 
-						    $output = ob_get_clean(); echo rtrim($output, ', '); ?></small>
+							<small><strong>Tempo:</strong> <?php echo $tempo_output; ?></small>
 						</div>
 						<div class="move-clear"></div>
 					</div>

--- a/single-songs.php
+++ b/single-songs.php
@@ -6,41 +6,94 @@
 					<div class="col span_6">
 						<div class="inner-wrap">
 							<h1 class="entry-title"><?php the_title(); ?></h1>
-							<?php $terms = get_the_terms( $post->ID , 'performer' ); 
-							    foreach ( $terms as $term ) {
-							        $term_link = get_term_link( $term, 'performer' );
-							        if( is_wp_error( $term_link ) )
-							        continue;
-							    echo '<a href="' . $term_link . '"><strong>' . $term->name . '</strong></a>';
-							    } 
-							?> • <strong>Key</strong> (<?php $terms = get_the_terms( $post->ID , 'key' ); 
-							    foreach ( $terms as $term ) {
-							        $term_link = get_term_link( $term, 'key' );
-							        if( is_wp_error( $term_link ) )
-							        continue;
-							    echo '<a href="' . $term_link . '"><strong>' . $term->name . '</strong></a>' . ', ';
-							    } 
-							    $output = ob_get_clean(); echo rtrim($output, ', ');
-							?>)
-							<br/>
-							<strong>Tempo:</strong> <?php $terms = get_the_terms( $post->ID , 'tempo' ); 
-							    foreach ( $terms as $term ) {
-							        $term_link = get_term_link( $term, 'tempo' );
-							        if( is_wp_error( $term_link ) )
-							        continue;
-							    echo '<a href="' . $term_link . '">' . $term->name . '</a>' . ', ';
-							    } 
-							    $output = ob_get_clean(); echo rtrim($output, ', ');
-							?> • 
-<strong>Theme:</strong> <?php $terms = get_the_terms( $post->ID , 'themes' ); 
-							    foreach ( $terms as $term ) {
-							        $term_link = get_term_link( $term, 'themes' );
-							        if( is_wp_error( $term_link ) )
-							        continue;
-							    echo '<a href="' . $term_link . '">' . $term->name . '</a>' . ', ';
-							    } 
-							    $output = ob_get_clean(); echo rtrim($output, ', ');
+														<?php
+								$performer_output = '<strong>' . esc_html__( 'N/A', 'music-director' ) . '</strong>';
+								$performer_terms  = get_the_terms( get_the_ID(), 'performer' );
+
+								if ( ! empty( $performer_terms ) && ! is_wp_error( $performer_terms ) ) {
+									$performer_names = wp_list_pluck( $performer_terms, 'name', 'term_id' );
+									$performer_links = array();
+
+									foreach ( $performer_terms as $performer_term ) {
+										$performer_name = isset( $performer_names[ $performer_term->term_id ] ) ? $performer_names[ $performer_term->term_id ] : $performer_term->name;
+										$performer_link = get_term_link( $performer_term, 'performer' );
+
+										if ( ! is_wp_error( $performer_link ) ) {
+											$performer_links[] = '<a href="' . esc_url( $performer_link ) . '"><strong>' . esc_html( $performer_name ) . '</strong></a>';
+										} else {
+											$performer_links[] = '<strong>' . esc_html( $performer_name ) . '</strong>';
+										}
+									}
+
+									$performer_output = implode( ', ', $performer_links );
+								}
+
+								$key_output = '<strong>' . esc_html__( 'N/A', 'music-director' ) . '</strong>';
+								$key_terms  = get_the_terms( get_the_ID(), 'key' );
+
+								if ( ! empty( $key_terms ) && ! is_wp_error( $key_terms ) ) {
+									$key_names = wp_list_pluck( $key_terms, 'name', 'term_id' );
+									$key_links = array();
+
+									foreach ( $key_terms as $key_term ) {
+										$key_name = isset( $key_names[ $key_term->term_id ] ) ? $key_names[ $key_term->term_id ] : $key_term->name;
+										$key_link = get_term_link( $key_term, 'key' );
+
+										if ( ! is_wp_error( $key_link ) ) {
+											$key_links[] = '<a href="' . esc_url( $key_link ) . '"><strong>' . esc_html( $key_name ) . '</strong></a>';
+										} else {
+											$key_links[] = '<strong>' . esc_html( $key_name ) . '</strong>';
+										}
+									}
+
+									$key_output = implode( ', ', $key_links );
+								}
+
+								$tempo_output = esc_html__( 'N/A', 'music-director' );
+								$tempo_terms  = get_the_terms( get_the_ID(), 'tempo' );
+
+								if ( ! empty( $tempo_terms ) && ! is_wp_error( $tempo_terms ) ) {
+									$tempo_names = wp_list_pluck( $tempo_terms, 'name', 'term_id' );
+									$tempo_links = array();
+
+									foreach ( $tempo_terms as $tempo_term ) {
+										$tempo_name = isset( $tempo_names[ $tempo_term->term_id ] ) ? $tempo_names[ $tempo_term->term_id ] : $tempo_term->name;
+										$tempo_link = get_term_link( $tempo_term, 'tempo' );
+
+										if ( ! is_wp_error( $tempo_link ) ) {
+											$tempo_links[] = '<a href="' . esc_url( $tempo_link ) . '">' . esc_html( $tempo_name ) . '</a>';
+										} else {
+											$tempo_links[] = esc_html( $tempo_name );
+										}
+									}
+
+									$tempo_output = implode( ', ', $tempo_links );
+								}
+
+								$theme_output = esc_html__( 'N/A', 'music-director' );
+								$theme_terms  = get_the_terms( get_the_ID(), 'themes' );
+
+								if ( ! empty( $theme_terms ) && ! is_wp_error( $theme_terms ) ) {
+									$theme_names = wp_list_pluck( $theme_terms, 'name', 'term_id' );
+									$theme_links = array();
+
+									foreach ( $theme_terms as $theme_term ) {
+										$theme_name = isset( $theme_names[ $theme_term->term_id ] ) ? $theme_names[ $theme_term->term_id ] : $theme_term->name;
+										$theme_link = get_term_link( $theme_term, 'themes' );
+
+										if ( ! is_wp_error( $theme_link ) ) {
+											$theme_links[] = '<a href="' . esc_url( $theme_link ) . '">' . esc_html( $theme_name ) . '</a>';
+										} else {
+											$theme_links[] = esc_html( $theme_name );
+										}
+									}
+
+									$theme_output = implode( ', ', $theme_links );
+								}
 							?>
+							<?php echo $performer_output; ?> • <strong>Key</strong> (<?php echo $key_output; ?>)
+							<br/>
+							<strong>Tempo:</strong> <?php echo $tempo_output; ?> •<strong>Theme:</strong> <?php echo $theme_output; ?>
 							
 						</div>
 					</div>

--- a/taxonomy-themes.php
+++ b/taxonomy-themes.php
@@ -62,29 +62,56 @@
              ?>
 			 
 			 <?php foreach(get_posts($args) as $p) : ?>
+			<?php
+			$song_id      = $p->ID;
+			$key_output   = esc_html__( 'N/A', 'music-director' );
+			$theme_output = esc_html__( 'N/A', 'music-director' );
+
+			$key_terms = get_the_terms( $song_id, 'key' );
+			if ( ! empty( $key_terms ) && ! is_wp_error( $key_terms ) ) {
+				$key_names = wp_list_pluck( $key_terms, 'name', 'term_id' );
+				$key_links = array();
+
+				foreach ( $key_terms as $key_term ) {
+					$key_name = isset( $key_names[ $key_term->term_id ] ) ? $key_names[ $key_term->term_id ] : $key_term->name;
+					$key_link = get_term_link( $key_term, 'key' );
+
+					if ( ! is_wp_error( $key_link ) ) {
+						$key_links[] = '<a href="' . esc_url( $key_link ) . '">' . esc_html( $key_name ) . '</a>';
+					} else {
+						$key_links[] = esc_html( $key_name );
+					}
+				}
+
+				$key_output = implode( ', ', $key_links );
+			}
+
+			$theme_terms = get_the_terms( $song_id, 'themes' );
+			if ( ! empty( $theme_terms ) && ! is_wp_error( $theme_terms ) ) {
+				$theme_names = wp_list_pluck( $theme_terms, 'name', 'term_id' );
+				$theme_links = array();
+
+				foreach ( $theme_terms as $theme_term ) {
+					$theme_name = isset( $theme_names[ $theme_term->term_id ] ) ? $theme_names[ $theme_term->term_id ] : $theme_term->name;
+					$theme_link = get_term_link( $theme_term, 'themes' );
+
+					if ( ! is_wp_error( $theme_link ) ) {
+						$theme_links[] = '<a href="' . esc_url( $theme_link ) . '">' . esc_html( $theme_name ) . '</a>';
+					} else {
+						$theme_links[] = esc_html( $theme_name );
+					}
+				}
+
+				$theme_output = implode( ', ', $theme_links );
+			}
+			?>
 			<div class="col span_12">
-				<div class="col span_4"><a href="<?php the_permalink(); ?>"><strong><?php echo $p->post_title; ?></strong></a></div>
+				<div class="col span_4"><a href="<?php echo esc_url( get_permalink( $p ) ); ?>"><strong><?php echo esc_html( $p->post_title ); ?></strong></a></div>
 				<div class="col span_2">
-					<?php $terms = get_the_terms( $post->ID , 'key' ); 
-					    foreach ( $terms as $term ) {
-					        $term_link = get_term_link( $term, 'key' );
-					        if( is_wp_error( $term_link ) )
-					        continue;
-					    echo '<a href="' . $term_link . '">' . $term->name . '</a>' . ', ';
-					    } 
-					    $output = ob_get_clean(); echo rtrim($output, ', ');
-					?>
+					<?php echo $key_output; ?>
 				</div>
 				<div class="col span_6">
-					<?php $terms = get_the_terms( $post->ID , 'themes' ); 
-					    foreach ( $terms as $term ) {
-					        $term_link = get_term_link( $term, 'themes' );
-					        if( is_wp_error( $term_link ) )
-					        continue;
-					    echo '<a href="' . $term_link . '">' . $term->name . '</a>' . ', ';
-					    } 
-					    $output = ob_get_clean(); echo rtrim($output, ', ');
-					?>
+					<?php echo $theme_output; ?>
 				</div>
 			</div>
 				


### PR DESCRIPTION
## Summary
- validate performer, key, tempo, and theme taxonomies on the single song template and render sanitized lists with fallbacks
- update the songs archive card to collect term names safely and output comma-separated lists instead of relying on output buffers
- refactor the theme taxonomy template to reuse term data for each song, escape the results, and provide fallback text when no terms exist

## Testing
- php -l single-songs.php
- php -l archive-songs.php
- php -l taxonomy-themes.php

------
https://chatgpt.com/codex/tasks/task_e_68cfd65145cc8320bf4b6e8d2741845e